### PR TITLE
Update van Informatieobject, Beperkgebruikgegevens en uitbreiding met Dekkingstijdgegevens, Eventgegevens

### DIFF
--- a/mdto.py
+++ b/mdto.py
@@ -341,6 +341,31 @@ class DekkingInTijdGegevens:
         return root
 
 
+@dataclass
+class EventGegevens:
+    eventType: BegripGegevens
+    eventTijd: str  # Aangepast naar str
+    eventVerantwoordelijkeActor: VerwijzingGegevens
+    eventResultaat: str
+
+    def to_xml(self) -> ET.Element:
+        root = ET.Element("event")
+
+        root.append(self.eventType.to_xml("eventType"))
+
+        event_tijd_elem = ET.SubElement(root, "eventTijd")
+        event_tijd_elem.text = self.eventTijd
+
+        root.append(
+            self.eventVerantwoordelijkeActor.to_xml("eventVerantwoordelijkeActor")
+        )
+
+        event_resultaat_elem = ET.SubElement(root, "eventResultaat")
+        event_resultaat_elem.text = self.eventResultaat
+
+        return root
+
+
 # TODO: this should be a subclass of a general object class
 @dataclass
 class Informatieobject:

--- a/mdto.py
+++ b/mdto.py
@@ -309,14 +309,20 @@ class BeperkingGebruikGegevens:
         root = ET.Element("beperkingGebruik")
 
         root.append(self.beperkingGebruikType.to_xml("beperkingGebruikType"))
-        
-        nadereBeschrijving = ET.SubElement(root, "beperkingGebruikNadereBeschrijving")
-        nadereBeschrijving.text = self.beperkingGebruikNadereBeschrijving
 
-        root.append(self.beperkingGebruikDocumentatie.to_xml("beperkingGebruikDocumentatie"))
-        
-        # TODO: also add beperkingGebruikTermijn
-        
+        if self.beperkingGebruikNadereBeschrijving:
+            nadereBeschrijving = ET.SubElement(
+                root, "beperkingGebruikNadereBeschrijving"
+            )
+            nadereBeschrijving.text = self.beperkingGebruikNadereBeschrijving
+        if self.beperkingGebruikDocumentatie:
+            root.append(
+                self.beperkingGebruikDocumentatie.to_xml("beperkingGebruikDocumentatie")
+            )
+        if self.beperkingGebruikTermijn:
+            beperkingGebruikTermijn = ET.SubElement(root, "beperkingGebruikTermijn")
+            beperkingGebruikTermijn.text = self.beperkingGebruikTermijn
+
         return root
 
 # TODO: this should be a subclass of a general object class

--- a/mdto.py
+++ b/mdto.py
@@ -325,6 +325,22 @@ class BeperkingGebruikGegevens:
 
         return root
 
+@dataclass
+class DekkingInTijdGegevens:
+    dekkingInTijdType: BegripGegevens
+    beginDatum: str
+    eindDatum: str
+
+    def to_xml(self) -> ET.Element:
+        root = ET.Element("dekkingInTijd")
+        root.append(self.dekkingInTijdType.to_xml("dekkingInTijdType"))
+        begin_datum_elem = ET.SubElement(root, "dekkingInTijdBegindatum")
+        begin_datum_elem.text = self.beginDatum
+        eind_datum_elem = ET.SubElement(root, "dekkingInTijdEinddatum")
+        eind_datum_elem.text = self.eindDatum
+        return root
+
+
 # TODO: this should be a subclass of a general object class
 @dataclass
 class Informatieobject:

--- a/mdto.py
+++ b/mdto.py
@@ -678,7 +678,7 @@ def detect_verwijzing(informatieobject: TextIO) -> VerwijzingGegevens:
 
     if naam is None:
         # this ought to be really rare
-        _warn(f"informatieobject in {informatieobject_xml.name} " "lacks a <naam> tag.")
+        _warn(f"informatieobject in {informatieobject} " "lacks a <naam> tag.")
         return None
     else:
         return VerwijzingGegevens(naam.text, id_gegevens)


### PR DESCRIPTION
**Toevoeging van Klassen**
-  Dekkingstijdgegevens
- Eventgegevens

Ik heb een aantal klassen toegevoegd die nodig zijn om minimaal te voldoen aan de MDTO-vereisten voor een specifieke klant. Let op: niet alle benodigde klassen zijn momenteel geïmplementeerd.

**Bijwerken van Klassen**
- Informatieobject
- Beperkgebruikgegevens

Twee bestaande klassen zijn bijgewerkt zodat ze voldoen aan de MDTO XSD en vollediger zijn. Het InformatieObject is aangepast zodat de nieuw toegevoegde klassen optioneel zijn bij het aanmaken van een object. Dit betekent dat het object niet afhankelijk is van de aanwezigheid van deze klassen.

**Codeformattering** 
De code is geformatteerd met behulp van de Black formatter voor een consistente en leesbare opmaak. Ik kan me voorstellen dat je niet op dit laatste zit te wachten dus die commit zou ik ongedaan kunnen maken. 

**Bugfixes**
Een kleine bugfix waar de niet bestaande variabele informatieobject_xml werd aangeroepen
