### PR TITLE
Add raadpleeglocatie class

### DIFF
--- a/mdto.py
+++ b/mdto.py
@@ -387,8 +387,9 @@ class RaadpleeglocatieGegevens:
 
     @raadpleeglocatieOnline.setter
     def raadpleeglocatieOnline(self, url: str):
-        # if url is not set, it's not None, but an empty "property" object
-        if isinstance(url, property): # check if empty
+        # if url is not set, (e.g. when calling RaadpleegLocatieGegevens() without arguments)
+        # it will not be None, but rather an empty "property" object
+        if isinstance(url, property) or url is None: # check if empty
             self._raadpleeglocatieOnline = None
         elif validators.url(url):
             self._raadpleeglocatieOnline = url

--- a/mdto.py
+++ b/mdto.py
@@ -350,6 +350,53 @@ class EventGegevens:
         return root
 
 
+@dataclass
+class RaadpleeglocatieGegevens:
+    """MDTO raadpleeglocatie class.
+
+    MDTO docs: https://www.nationaalarchief.nl/archiveren/mdto/raadpleeglocatie
+
+    Args:
+        raadpleeglocatieFysiek (VerwijzingGegevens, optional): Fysieke raadpleeglocatie van het informatieobject
+        raadpleeglocatieOnline (str, optional): Online raadpleeglocatie van het informatieobject; moet een valide URL zijn
+    """
+
+    raadpleeglocatieFysiek: VerwijzingGegevens = None
+    raadpleeglocatieOnline: str = None
+
+    def to_xml(self):
+        root = ET.Element("raadpleeglocatie")
+
+        # In MDTO, raadpleeglocatie may have no children, strangely enough
+        if self.raadpleeglocatieFysiek:
+            root.append(self.raadpleeglocatieFysiek.to_xml('raadpleeglocatieFysiek'))
+
+        if self.raadpleeglocatieOnline:
+            raadpleeglocatie_online_elem = ET.SubElement(root, "raadpleeglocatieOnline")
+            raadpleeglocatie_online_elem.text = self.raadpleeglocatieOnline
+
+    @property
+    def raadpleeglocatieOnline(self):
+        """Value of MDTO `raadpleeglocatieOnline` tag.
+
+        Valid value: any RFC 3986 compliant URI
+
+        MDTO docs: https://www.nationaalarchief.nl/archiveren/mdto/raadpleeglocatieOnline
+        """
+        return self._raadpleeglocatieOnline
+
+    @raadpleeglocatieOnline.setter
+    def raadpleeglocatieOnline(self, url: str):
+        # if url is not set, it's not None, but an empty "property" object
+        if isinstance(url, property): # check if empty
+            self._raadpleeglocatieOnline = None
+        elif validators.url(url):
+            self._raadpleeglocatieOnline = url
+        else:
+            _warn(f"URL '{url}' is malformed.")
+            self._raadpleeglocatieOnline = url
+
+
 # TODO: this should be a subclass of a general object class
 @dataclass
 class Informatieobject:
@@ -399,6 +446,7 @@ class Informatieobject:
     isOnderdeelVan: VerwijzingGegevens = None
     archiefvormer: VerwijzingGegevens | List[VerwijzingGegevens] = None
     beperkingGebruik: BeperkingGebruikGegevens | List[BeperkingGebruikGegevens] = None
+    raadpleeglocatie: RaadpleeglocatieGegevens = None
     # TODO: add other elements
 
     def to_xml(self) -> ET.ElementTree:


### PR DESCRIPTION
Niet veel speciaals. 

Ik begin wel steeds meer te twijfelen of validatie logica een taak van dit project moet zijn (daar is de XSD immers voor bedoeld). Anderzijds, het is een misschien een goed streven om er voor te zorgen dat men geen invalide XML bestanden kan produceren. 

Deze commit toont ook weer aan dat er, na https://github.com/Regionaal-Archief-Rivierenland/mdto.py/pull/4, nog iets moet gebeuren met `_warn()` en `_error()`. 

```python
       else:
            _warn(f"URL '{url}' is malformed.")
            self._raadpleeglocatieOnline = url
```

Het printen van een warning is an sich goed, maar de executie zal nu niet verder gaan, behalve als je ergens eerder de variabele `_force` op `True` hebt gezet. Dit is lelijk en een beetje omslachtig/onpythonic. 