### PR TITLE
Voeg officiele installatie methode toe

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ sudo pip install . # Windows gebruikers kunnen "sudo" hier weglaten
 
 <details>
 <summary>Windows</summary>
+
 ``` shell
 git clone https://github.com/Regionaal-Archief-Rivierenland/mdto.py
 cd mdto.py
@@ -70,6 +71,7 @@ pip install .
 
 <details>
 <summary>Linux/WSL/*nix</summary>
+
 ``` shell
 git clone https://github.com/Regionaal-Archief-Rivierenland/mdto.py
 cd mdto.py/

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 
 
 * Python 3.11 of nieuwer.
-* `mdto.py` werkt alleen als het programma `fido` in je `PATH` staat. Als je de instructies hieronder volgt gebeurd dit automatisch.
+* Sommige functies van `mdto.py` werken alleen als het programma `fido` in je `PATH` staat. Als je de instructies hieronder volgt gebeurd dit automatisch.
 
 ## Systeem-brede installatie
 

--- a/README.md
+++ b/README.md
@@ -43,23 +43,41 @@
 
 ## Afhankelijkheden
 
-Om `mdto.py` te gebruiken heb je het volgende nodig:
 
-* Python 3.11 of nieuwer
-* [fido](https://github.com/openpreserve/fido) (voor pronom detectie)
-* De [validators python library](https://pypi.org/project/validators/) (voor het valideren van URLs)
-  
-De laatste twee afhankelijkheden kunnen bijv. via pip geinstalleerd worden:
+* Python 3.11 of nieuwer.
+* `mdto.py` werkt alleen als het programma `fido` in je `PATH` staat. Als je de instructies hieronder volgt gebeurd dit automatisch.
 
-```shell
-pip install opf-fido validators
+## Systeem-brede installatie
+
+``` shell
+git clone https://github.com/Regionaal-Archief-Rivierenland/mdto.py
+cd mdto.py
+sudo pip install . # Windows gebruikers kunnen "sudo" hier weglaten
 ```
 
-De `fido` binary moet in je `PATH` staan.
+## Binnen een virtual environment
 
-## Installatie van `mdto.py`
+<details>
+<summary>Windows</summary>
+``` shell
+git clone https://github.com/Regionaal-Archief-Rivierenland/mdto.py
+cd mdto.py
+python3 -m venv mdto_env
+mdto_env\Scripts\activate
+pip install .
+```
+</details>
 
-**TODO**
+<details>
+<summary>Linux/WSL/*nix</summary>
+``` shell
+git clone https://github.com/Regionaal-Archief-Rivierenland/mdto.py
+cd mdto.py/
+python3 -m venv mdto_env
+source mdto_env/bin/activate
+pip install .
+```
+</details>
 
 # `mdto.py` als python library
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ sudo pip install . # Windows gebruikers kunnen "sudo" hier weglaten
 ``` shell
 git clone https://github.com/Regionaal-Archief-Rivierenland/mdto.py
 cd mdto.py
-python3 -m venv mdto_env
+python -m venv mdto_env
 mdto_env\Scripts\activate
 pip install .
 ```
@@ -75,7 +75,7 @@ pip install .
 ``` shell
 git clone https://github.com/Regionaal-Archief-Rivierenland/mdto.py
 cd mdto.py/
-python3 -m venv mdto_env
+python -m venv mdto_env
 source mdto_env/bin/activate
 pip install .
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[project]
+name = "mdto.py"
+version = "0.0.1"
+authors = [
+  { name="Rijnder Wever", email="rwever@rarivierland.nl"},
+  { name="Wilmar van Ommeren", email="w.van.ommeren@zeeuwsarchief.nl"},
+]
+license = { file = "LICENSE"}
+description = "Library voor het genereren van MDTO XML bestanden"
+readme = "README.md"
+requires-python = ">=3.11"
+keywords = ["MDTO", "archiving"]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+    "Operating System :: OS Independent",
+]
+
+dependencies = [
+    "validators",
+    "opf-fido",
+]
+
+[project.urls]
+Homepage = "https://github.com/Regionaal-Archief-Rivierenland/mdto.py"
+Issues = "https://github.com/Regionaal-Archief-Rivierenland/mdto.py/issues"
+
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Ik had hier nog geen ervaring mee, maar hierbij. 

Uiteindelijk zou het beter zijn om dit project op PyPi te gooien, maar eigenlijk vind ik het project nog net niet af genoeg om dat te doen. Dit is al een stapje in die richting, tho. 

Wat dit wel mogelijk maakt is dat ik collega's/andere machines zonder al teveel gedoe deze library kan laten installeren. 

Ik heb geen idee hoe mensen het liefst dingen op een niet systeem-brede manier installeren. Ik denk dat `venv`s goed genoeg zijn, maar ik heb  —  ietwat opvallend —  vrijwel nooit de behoefte gehad dat hele mechanisme te gebruiken. Dus als de methodiek beter/anders kan, lmk. 